### PR TITLE
feat AMMP-1227: enable local execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+PROJECT_NAME=ammp-edge
+
+include .env
+
+.PHONY: docker-build docker-run docker-clean clean run
+
+docker-build:
+	docker-compose -f docker-compose.yml build
+
+docker-run:
+	$(MAKE) docker-build
+	docker-compose -f docker-compose.yml up -d
+
+docker-clean:
+	docker-compose -f docker-compose.yml down
+	docker rmi -f ${IMAGE_NAME}
+
+clean:
+	find . -name '*.pyc' -delete
+	find . -name '__pycache__' -type d | xargs rm -fr
+	rm -rf .pytest_cache
+
+local-prepare:
+	mkdir -p .local
+	cp config/remote.yaml .local/
+	cp -a provisioning .local/
+	ln -sf ../drivers .local/
+	mkdir -p .local/data
+
+local-run:
+	$(MAKE) docker-run
+	set -a && . ./.env
+	SNAP=.local \
+	SNAP_COMMON=.local/data \
+	pipenv run ammp_edge

--- a/Pipfile
+++ b/Pipfile
@@ -31,3 +31,7 @@ paho-mqtt = "*"
 
 [requires]
 python_version = "3.6"
+
+
+[scripts]
+emmp_edge = "python3 src/ammp_edge.py"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.3'
+
+services:
+  redis:
+    image: redis:5.0.7
+    command: redis-server /usr/local/etc/redis/redis.conf --bind 0.0.0.0
+    ports:
+      - "127.0.0.1:6379:6379"
+    volumes:
+      - $PWD/.local/data:/var/lib/redis
+      - $PWD/config/redis.conf:/usr/local/etc/redis/redis.conf

--- a/remote.yaml
+++ b/remote.yaml
@@ -1,1 +1,0 @@
-config/remote.yaml


### PR DESCRIPTION
This enables local execution of the code.

Run
```
make local-prepare
```
once. This creates copies of key files under `.local` (as well as a symlink to the drivers directory). Modify these files as necessary.

Then
```
make local-run
```
to run the code.

The latter will also run Redis in a Docker container.