### PR TITLE
Ammp 1269 improvement mqtt schema

### DIFF
--- a/src/data_mgmt/datapusher.py
+++ b/src/data_mgmt/datapusher.py
@@ -173,7 +173,7 @@ class DataPusher(threading.Thread):
             # Append offset between time that reading was taken and current time
             readout['m']['reading_offset'] = int((arrow.utcnow() - arrow.get(readout['t'])).total_seconds() -
                                                     readout['m']['reading_duration'])
-            logger.debug(f"PUSH [MQTT] Device-based readout: {readout}")
+            logger.debug(f"PUSH [mqtt] Device-based readout: {readout}")
             return self._session.publish(readout)
         else:
             logger.warning(f"Data endpoint type '{self._dep.get('type')}' not recognized")

--- a/src/data_mgmt/datapusher.py
+++ b/src/data_mgmt/datapusher.py
@@ -97,10 +97,11 @@ class DataPusher(threading.Thread):
         if self._dep.get('type') == 'api':
             # Push to API endpoint
             try:
-                # Append offset between time that reading was taken and current time
-                readout['reading_offset'] = int((arrow.utcnow() - arrow.get(readout['t'])).total_seconds() - readout['m']['reading_duration'])
                 # Transform the device-based readout to the older API format
                 readout = convert_to_api_payload(readout, self._node.config['readings'])
+                # Append offset between time that reading was taken and current time
+                readout['fields']['reading_offset'] = int((arrow.utcnow() - arrow.get(readout['time'])).total_seconds()
+                                                          - readout['fields']['reading_duration'])
                 logger.debug(f"PUSH [API]. API-Based Readout: {readout}")
             except:
                 logger.exception('Could not construct final data payload to push')

--- a/src/data_mgmt/datapusher.py
+++ b/src/data_mgmt/datapusher.py
@@ -89,6 +89,8 @@ class DataPusher(threading.Thread):
         # This ensures that any modifications are only local to this function, and do not affect the original (in case
         # it needs to be pushed back into the queue)
 
+        timestamp_iso = arrow.get(readout_to_push['t']).isoformat()
+
         readout = deepcopy(readout_to_push)
         if self._dep.get('type') == 'api':
             # Push to API endpoint
@@ -111,17 +113,17 @@ class DataPusher(threading.Thread):
                     timeout=self._node.config.get('push_timeout') or self._dep['config'].get('timeout') or 120
                 )
             except requests.exceptions.ConnectionError:
-                logger.warning(f"Connection error while trying to push data at {readout['time']} to API.")
+                logger.warning(f"Connection error while trying to push data at {timestamp_iso} to API.")
                 return False
             except requests.exceptions.Timeout:
-                logger.warning(f"Timeout error while trying to push data at {readout['time']} to API.")
+                logger.warning(f"Timeout error while trying to push data at {timestamp_iso} to API.")
                 return False
             except:
-                logger.warning(f"Exception while trying to push data at {readout['time']} to API.", exc_info=True)
+                logger.warning(f"Exception while trying to push data at {timestamp_iso} to API.", exc_info=True)
                 return False
 
             if r.status_code != 200:
-                logger.warning(f"Error code {r.status_code} while trying to push data point at {readout['time']}.")
+                logger.warning(f"Error code {r.status_code} while trying to push data point at {timestamp_iso}.")
                 return False
 
             try:

--- a/src/data_mgmt/datapusher.py
+++ b/src/data_mgmt/datapusher.py
@@ -97,11 +97,10 @@ class DataPusher(threading.Thread):
         if self._dep.get('type') == 'api':
             # Push to API endpoint
             try:
+                # Append offset between time that reading was taken and current time
+                readout['reading_offset'] = int((arrow.utcnow() - arrow.get(readout['t'])).total_seconds() - readout['m']['reading_duration'])
                 # Transform the device-based readout to the older API format
                 readout = convert_to_api_payload(readout, self._node.config['readings'])
-                # Append offset between time that reading was taken and current time
-                readout['fields']['reading_offset'] = int((arrow.utcnow() - arrow.get(readout['time'])).total_seconds()
-                                                          - readout['fields']['reading_duration'])
                 logger.debug(f"PUSH [API]. API-Based Readout: {readout}")
             except:
                 logger.exception('Could not construct final data payload to push')

--- a/src/data_mgmt/datapusher.py
+++ b/src/data_mgmt/datapusher.py
@@ -70,7 +70,7 @@ class DataPusher(threading.Thread):
                 else:
                     # For some reason the point wasn't pushed successfully, so we should put it back in the queue
                     logger.warning(f"PUSH: [{self.dep_name}] Did not work. "
-                                   f"Putting readout at {readout['t']} back to queue")
+                                   f"Putting readout at {arrow.Arrow.fromtimestamp(readout['t'])} back to queue")
                     self._queue.put(readout)
 
                     if self._is_default_endpoint:
@@ -173,7 +173,7 @@ class DataPusher(threading.Thread):
             # Append offset between time that reading was taken and current time
             readout['m']['reading_offset'] = int((arrow.utcnow() - arrow.get(readout['t'])).total_seconds() -
                                                     readout['m']['reading_duration'])
-            logger.debug(f"PUSH [mqtt] Device-based readout: {readout}")
+            logger.debug(f"PUSH [MQTT] Device-based readout: {readout}")
             return self._session.publish(readout)
         else:
             logger.warning(f"Data endpoint type '{self._dep.get('type')}' not recognized")

--- a/src/data_mgmt/datapusher.py
+++ b/src/data_mgmt/datapusher.py
@@ -94,7 +94,7 @@ class DataPusher(threading.Thread):
             # Push to API endpoint
             try:
                 # Append offset between time that reading was taken and current time
-                readout['reading_offset'] = int(
+                readout['m']['reading_offset'] = int(
                     arrow.utcnow().timestamp - readout['t'] - readout['m']['reading_duration']
                 )
                 # Transform the device-based readout to the older API format
@@ -143,7 +143,7 @@ class DataPusher(threading.Thread):
         elif self._dep.get('type') == 'influxdb':
             try:
                 # Append offset between time that reading was taken and current time
-                readout['reading_offset'] = int(
+                readout['m']['reading_offset'] = int(
                     arrow.utcnow().timestamp - readout['t'] - readout['m']['reading_duration']
                 )
                 # Transform the device-based readout to the older API format

--- a/src/data_mgmt/datapusher.py
+++ b/src/data_mgmt/datapusher.py
@@ -40,9 +40,7 @@ class DataPusher(threading.Thread):
         else:
             logger.warning(f"Data endpoint type '{dep.get('type')}' not recognized")
 
-
     def run(self):
-
         while not self._node.events.do_shutdown.is_set():
 
             # queue.get() blocks the current thread until an item is retrieved
@@ -96,7 +94,9 @@ class DataPusher(threading.Thread):
             # Push to API endpoint
             try:
                 # Append offset between time that reading was taken and current time
-                readout['reading_offset'] = int(arrow.utcnow().timestamp - readout['t'] - readout['m']['reading_duration'])
+                readout['reading_offset'] = int(
+                    arrow.utcnow().timestamp - readout['t'] - readout['m']['reading_duration']
+                )
                 # Transform the device-based readout to the older API format
                 readout = convert_to_api_payload(readout, self._node.config['readings'])
                 logger.debug(f"PUSH [API]. API-Based Readout: {readout}")
@@ -105,10 +105,11 @@ class DataPusher(threading.Thread):
                 return False
 
             try:
-                API_URL = self._dep['config']['host']
-                r = self._session.post(f"https://{API_URL}/api/{self._dep['config']['apiver']}/nodes/{self._node.node_id}/data",
-                                       json=readout,
-                                       timeout=self._node.config.get('push_timeout') or self._dep['config'].get('timeout') or 120)
+                r = self._session.post(
+                    f"https://{self._dep['config']['host']}/api/{self._dep['config']['apiver']}/nodes/{self._node.node_id}/data",
+                    json=readout,
+                    timeout=self._node.config.get('push_timeout') or self._dep['config'].get('timeout') or 120
+                )
             except requests.exceptions.ConnectionError:
                 logger.warning(f"Connection error while trying to push data at {readout['time']} to API.")
                 return False
@@ -142,7 +143,9 @@ class DataPusher(threading.Thread):
         elif self._dep.get('type') == 'influxdb':
             try:
                 # Append offset between time that reading was taken and current time
-                readout['reading_offset'] = int(arrow.utcnow().timestamp - readout['t'] - readout['m']['reading_duration'])
+                readout['reading_offset'] = int(
+                    arrow.utcnow().timestamp - readout['t'] - readout['m']['reading_duration']
+                )
                 # Transform the device-based readout to the older API format
                 readout = convert_to_api_payload(readout, self._node.config['readings'])
                 # Set measurement where data should be written
@@ -167,7 +170,9 @@ class DataPusher(threading.Thread):
 
         elif self._dep.get('type') == 'mqtt':
             # Append offset between time that reading was taken and current time
-            readout['m']['reading_offset'] = int(arrow.utcnow().timestamp - readout['t'] - readout['m']['reading_duration'])
+            readout['m']['reading_offset'] = int(
+                arrow.utcnow().timestamp - readout['t'] - readout['m']['reading_duration']
+            )
             logger.debug(f"PUSH [mqtt] Device-based readout: {readout}")
             return self._session.publish(readout)
         else:

--- a/src/data_mgmt/helpers/convert_to_api_payload.py
+++ b/src/data_mgmt/helpers/convert_to_api_payload.py
@@ -14,10 +14,10 @@ def convert_to_api_payload(readout, readings_from_config):
 	# fields is a dict will all the readings of all devices -- without the device id. This is done for backwards compatibility
 	fields = {}
 	# convert time from unix timestamp to date
-	readout['time'] = arrow.Arrow.fromtimestamp(readout['t']).strftime('%Y-%m-%dT%H:%M:%SZ')
+	readout['time'] = arrow.get(readout['t']).strftime('%Y-%m-%dT%H:%M:%SZ')
 	for rdg in readout['r']:
-		# delete device names and vendor ids, maybe a more elegant way ?
-		[rdg.pop(k, 'None') for k in ['_d', '_vid']]
+		# delete device names and vendor ids
+		[rdg.pop(k, None) for k in ['_d', '_vid']]
 		fields.update(rdg)
 	# get the old reading names from the config for backwards compatibility
 	for rdg in readings_from_config:
@@ -33,8 +33,6 @@ def convert_to_api_payload(readout, readings_from_config):
 	# moving reading offset under fields
 	readout['fields']['reading_offset'] = readout['reading_offset']
 	# removing sections from the devices-based dict
-	readout.pop('m')
-	readout.pop('r')
-	readout.pop('t')
-	readout.pop('reading_offset')
+	for k in ['m', 'r', 't', 'reading_offset']:
+		readout.pop(k)
 	return readout

--- a/src/data_mgmt/helpers/convert_to_api_payload.py
+++ b/src/data_mgmt/helpers/convert_to_api_payload.py
@@ -1,4 +1,5 @@
 import logging
+import arrow
 from copy import deepcopy
 
 logger = logging.getLogger(__name__)
@@ -12,9 +13,10 @@ def convert_to_api_payload(readout, readings_from_config):
 	readout = deepcopy(readout)
 	# fields is a dict will all the readings of all devices -- without the device id. This is done for backwards compatibility
 	fields = {}
-	for rdg in readout['device_readings']:
-		# delete device names, maybe a more elegant way ?
-		rdg.pop('dev_id', None)
+	readout['time'] = arrow.Arrow.fromtimestamp(readout['t']).strftime('%Y-%m-%dT%H:%M:%SZ')
+	for rdg in readout['r']:
+		# delete device names and vendor ids, maybe a more elegant way ?
+		[rdg.pop(k, 'None') for k in ['_d', '_vid']]
 		fields.update(rdg)
 	# get the old reading names from the config for backwards compatibility
 	for rdg in readings_from_config:
@@ -24,8 +26,10 @@ def convert_to_api_payload(readout, readings_from_config):
 				break
 	readout['fields'] = fields
 	# move snap_rev, reading_duration , and reading_offset under fields
-	for key in ['snap_rev', 'reading_duration', 'reading_offset']:
-		readout['fields'][key] = readout[key]
-		readout.pop(key)
-	readout.pop('device_readings')
+	logger.debug(f"[CONVERTING TO API, Readout: {readout}]")
+	for key in ['snap_rev', 'config_id', 'reading_duration']:
+		readout['fields'][key] = readout['m'][key]
+	readout.pop('m')
+	readout.pop('r')
+	readout.pop('t')
 	return readout

--- a/src/data_mgmt/helpers/convert_to_api_payload.py
+++ b/src/data_mgmt/helpers/convert_to_api_payload.py
@@ -26,7 +26,6 @@ def convert_to_api_payload(readout, readings_from_config):
 				break
 	readout['fields'] = fields
 	# move snap_rev, reading_duration , and reading_offset under fields
-	logger.debug(f"[CONVERTING TO API, Readout: {readout}]")
 	for key in ['snap_rev', 'config_id', 'reading_duration']:
 		readout['fields'][key] = readout['m'][key]
 	readout.pop('m')

--- a/src/data_mgmt/helpers/convert_to_api_payload.py
+++ b/src/data_mgmt/helpers/convert_to_api_payload.py
@@ -10,29 +10,29 @@ This module is currently used by the datapusher
 
 
 def convert_to_api_payload(readout, readings_from_config):
-	readout = deepcopy(readout)
-	# fields is a dict will all the readings of all devices -- without the device id. This is done for backwards compatibility
-	fields = {}
-	# convert time from unix timestamp to date
-	readout['time'] = arrow.get(readout['t']).strftime('%Y-%m-%dT%H:%M:%SZ')
-	for rdg in readout['r']:
-		# delete device names and vendor ids
-		[rdg.pop(k, None) for k in ['_d', '_vid']]
-		fields.update(rdg)
-	# get the old reading names from the config for backwards compatibility
-	for rdg in readings_from_config:
-		for key in fields:
-			if readings_from_config[rdg]['var'] == key:
-				fields[rdg] = fields.pop(key)
-				break
-	readout['fields'] = fields
-	# move snap_rev, reading_duration , and reading_offset under fields
-	for key in ['snap_rev', 'config_id', 'reading_duration']:
-		readout['fields'][key] = readout['m'][key]
+    readout = deepcopy(readout)
+    # fields is a dict will all the readings of all devices -- without the device id. This is done for backwards compatibility
+    fields = {}
+    # convert time from unix timestamp to date
+    readout['time'] = arrow.get(readout['t']).strftime('%Y-%m-%dT%H:%M:%SZ')
+    for rdg in readout['r']:
+        # delete device names and vendor ids
+        [rdg.pop(k, None) for k in ['_d', '_vid']]
+        fields.update(rdg)
+    # get the old reading names from the config for backwards compatibility
+    for rdg in readings_from_config:
+        for key in fields:
+            if readings_from_config[rdg]['var'] == key:
+                fields[rdg] = fields.pop(key)
+                break
+    readout['fields'] = fields
+    # move snap_rev, reading_duration , and reading_offset under fields
+    for key in ['snap_rev', 'config_id', 'reading_duration']:
+        readout['fields'][key] = readout['m'][key]
 
-	# moving reading offset under fields
-	readout['fields']['reading_offset'] = readout['reading_offset']
-	# removing sections from the devices-based dict
-	for k in ['m', 'r', 't', 'reading_offset']:
-		readout.pop(k)
-	return readout
+    # moving reading offset under fields
+    readout['fields']['reading_offset'] = readout['reading_offset']
+    # removing sections from the devices-based dict
+    for k in ['m', 'r', 't', 'reading_offset']:
+        readout.pop(k)
+    return readout

--- a/src/data_mgmt/helpers/convert_to_api_payload.py
+++ b/src/data_mgmt/helpers/convert_to_api_payload.py
@@ -26,13 +26,11 @@ def convert_to_api_payload(readout, readings_from_config):
                 fields[rdg] = fields.pop(key)
                 break
     readout['fields'] = fields
-    # move snap_rev, reading_duration , and reading_offset under fields
-    for key in ['snap_rev', 'config_id', 'reading_duration']:
+    # move snap_rev, config_id, reading_duration, and reading_offset under fields
+    for key in ['snap_rev', 'config_id', 'reading_duration', 'reading_offset']:
         readout['fields'][key] = readout['m'][key]
 
-    # moving reading offset under fields
-    readout['fields']['reading_offset'] = readout['reading_offset']
     # removing sections from the devices-based dict
-    for k in ['m', 'r', 't', 'reading_offset']:
+    for k in ['m', 'r', 't']:
         readout.pop(k)
     return readout

--- a/src/data_mgmt/helpers/convert_to_api_payload.py
+++ b/src/data_mgmt/helpers/convert_to_api_payload.py
@@ -11,7 +11,7 @@ DEVICE_ID_KEY = '_d'
 
 
 def convert_to_api_payload(readout, config_readings):
-    # convert time from unix timestamp to date
+    # Create API payload and convert time from unix timestamp to date
     api_payload = {
         'time': arrow.get(readout['t']).strftime('%Y-%m-%dT%H:%M:%SZ'),
         'fields': {}
@@ -23,7 +23,7 @@ def convert_to_api_payload(readout, config_readings):
             readout['r'], r['device'], r['var']
         )
         if value is None:
-            logger.warning(f"No readings for reading {rdg}: {r}")
+            logger.debug(f"No value for reading {rdg}: {r}")
             continue
         api_payload['fields'][rdg] = value
 
@@ -31,7 +31,7 @@ def convert_to_api_payload(readout, config_readings):
     for key in METADATA_FIELDS:
         api_payload['fields'][key] = readout['m'][key]
 
-    return readout
+    return api_payload
 
 
 def get_value_from_dev_readings(dev_readings, device, var):

--- a/src/data_mgmt/helpers/convert_to_api_payload.py
+++ b/src/data_mgmt/helpers/convert_to_api_payload.py
@@ -13,6 +13,7 @@ def convert_to_api_payload(readout, readings_from_config):
 	readout = deepcopy(readout)
 	# fields is a dict will all the readings of all devices -- without the device id. This is done for backwards compatibility
 	fields = {}
+	# convert time from unix timestamp to date
 	readout['time'] = arrow.Arrow.fromtimestamp(readout['t']).strftime('%Y-%m-%dT%H:%M:%SZ')
 	for rdg in readout['r']:
 		# delete device names and vendor ids, maybe a more elegant way ?
@@ -28,8 +29,12 @@ def convert_to_api_payload(readout, readings_from_config):
 	# move snap_rev, reading_duration , and reading_offset under fields
 	for key in ['snap_rev', 'config_id', 'reading_duration']:
 		readout['fields'][key] = readout['m'][key]
+
+	# moving reading offset under fields
+	readout['fields']['reading_offset'] = readout['reading_offset']
 	# removing sections from the devices-based dict
 	readout.pop('m')
 	readout.pop('r')
 	readout.pop('t')
+	readout.pop('reading_offset')
 	return readout

--- a/src/data_mgmt/helpers/convert_to_api_payload.py
+++ b/src/data_mgmt/helpers/convert_to_api_payload.py
@@ -28,6 +28,7 @@ def convert_to_api_payload(readout, readings_from_config):
 	# move snap_rev, reading_duration , and reading_offset under fields
 	for key in ['snap_rev', 'config_id', 'reading_duration']:
 		readout['fields'][key] = readout['m'][key]
+	# removing sections from the devices-based dict
 	readout.pop('m')
 	readout.pop('r')
 	readout.pop('t')

--- a/src/reader/get_readings.py
+++ b/src/reader/get_readings.py
@@ -156,9 +156,6 @@ def get_readout(node):
     # time that took to read all devices.
     readout['m']['reading_duration'] = (arrow.utcnow() - arrow.get(readout['t'])).total_seconds()
 
-    logger.debug(f"Device-based Readings: {dev_rdg}")
-    logger.debug(f"Device-based Readout: {readout}")
-
     if 'output' in node.config:
         # Get additional processed values (new model to be used for all readings in future)
         output_fields = get_output(dev_rdg, node.config['output'])

--- a/src/reader/get_readings.py
+++ b/src/reader/get_readings.py
@@ -154,7 +154,7 @@ def get_readout(node):
             logger.warning('Not all devices returned readings')
 
     # time that took to read all devices.
-    readout['m']['reading_duration'] = (arrow.utcnow() - arrow.get(readout['t'])).total_seconds()
+    readout['m']['reading_duration'] = arrow.utcnow().timestamp - readout['t']
 
     if 'output' in node.config:
         # Get additional processed values (new model to be used for all readings in future)

--- a/src/reader/get_readings.py
+++ b/src/reader/get_readings.py
@@ -246,7 +246,8 @@ def read_device(dev, readings, readout_q, dev_lock=None):
 
                 # Append to key-value store
                 fields['_d'] = dev['id']
-                fields['_vid'] = dev['vendor_id']
+                if 'vendor_id' in dev:
+                    fields['_vid'] = dev['vendor_id']
                 fields[rdg['var']] = value
 
                 # Also save within readings structure


### PR DESCRIPTION
Hi @svet-b, please have a look to this PR. 
changes here are mainly: naming, adding vendor_id and time in unix epoch (API payload still uses date-like format)
I have tested locally and I'm getting this as device-based readout (mqtt):

```
{
  "t": 1606918060,
  "r": [
    {
      "_d": "logger",
      "_vid": "3c:22:fb:63:d6:f3",
      "boot_time": 1606464128,
      "cpu_load": 3.142578125,
      "memory_usage": 66.3
    }
  ],
  "m": {
    "snap_rev": 0,
    "config_id": "43b9de6",
    "reading_duration": 0.006443,
    "reading_offset": 0
  }
}
```

And this for the API payload:
```
{
  "time": "2020-12-02T15:07:40Z",
  "fields": {
    "comms_lggr_boot_time": 1606464128,
    "comms_lggr_cpu_load": 3.142578125,
    "comms_lggr_mem_usage": 66.3,
    "snap_rev": 0,
    "config_id": "43b9de6",
    "reading_duration": 0.006443,
    "reading_offset": 0
  }
}
```

Let me know what can be improved ! 