### PR TITLE
AMMP-1387 Fixing irradiance sensor-driver malformation

### DIFF
--- a/drivers/ingburo_ss_rad.json
+++ b/drivers/ingburo_ss_rad.json
@@ -5,9 +5,8 @@
         "fncode": 4
     },
     "fields": {
-        "irradience": {"register": 0, "unit": "W/m2", "typecast": "float", "multiplier": 0.1, "description": "Irradiation on sensor surface"},
         "irradiance": {"register": 0, "unit": "W/m2", "typecast": "float", "multiplier": 0.1, "description": "Irradiation on sensor surface"},
-        "temp_ext": {"register": 2, "unit": "C", "typecast": "float", "multiplier": 0.1, "offset": -25, "description": "Ambient temperature", "valuemap": {"0x0": null}}},
+        "temp_ext": {"register": 2, "unit": "C", "typecast": "float", "multiplier": 0.1, "offset": -25, "description": "Ambient temperature", "valuemap": {"0x0": null}},
         "temp_pv": {"register": 1, "unit": "C", "typecast": "float", "multiplier": 0.1, "offset": -25, "description": "PV module temperature"}
     }
 }


### PR DESCRIPTION
Hello @svet-b 

While testing the new release, the logger couldn't load the irradiance driver. There was one extra curly bracket. (Pycharm also detects it, I just didn't see it)

I'll also like to deprecate the reading with the wrong spelling for all new snaps>600. 
We'll be updating all configs (and configs process) anyway, so there should not be in the near future any device-based logger running on the old "irradiEnce" 