### PR TITLE
change mqtt endpoint to prod

### DIFF
--- a/config/remote.yaml
+++ b/config/remote.yaml
@@ -12,6 +12,6 @@ data-endpoints:
   - name: mqtt
     type: mqtt
     config:
-      host: mqtt.stage.ammp.io
-      cert: ca-stage.crt
+      host: mqtt.ammp.io
+      cert: ca.crt
       port: 8883


### PR DESCRIPTION
Hey @svet-b I have tested on my machine, the payload in the MQTT **prod broker** looks like this: 

```
{
  "t": 1610613000,
  "r": [
    {
      "_d": "logger",
      "_vid": "strato-1",
      "boot_time": 1610360064,
      "cpu_load": 1.74267578125,
      "memory_usage": 66.3
    },
    {
      "cpu_load_calculated": 1.74267578125,
      "_d": "_calc",
      "_vid": "prod-calc-test"
    }
  ],
  "m": {
    "snap_rev": 0,
    "config_id": "6e91dec",
    "reading_duration": 0.004673004150390625,
    "reading_offset": 0
  }
}
```
You can see a "prod-calc-test" `vendor_id` for the calculated values (taken from the config top level `calc_vendor_id`)
It's not creating any devices as the `node_id` doesn't have any asset; just to keep it clean. 

Fixed:
- loading irradiance sensor correctly