### PR TITLE
AMMP-2044_Dynamic change of data endpoints from config + Fix: cummins driver ma…

### DIFF
--- a/drivers/cummins_ps0600.json
+++ b/drivers/cummins_ps0600.json
@@ -22,6 +22,6 @@
     "genset_state": {"description": "Genset state", "register": 10, "words": 1, "datatype": "uint16", "typecast": "int"},
     "freq": {"description": "Generator frequency", "register": 43, "words": 1, "datatype": "uint16", "typecast": "float", "multiplier": 0.01, "unit": "Hz"},
     "temp_coolant": {"description": "Coolant temperature", "register": 63, "words": 1, "datatype": "uint16", "typecast": "float", "multiplier": 0.1, "unit": "F"},
-    "oil_pressure": {"description": "Oil pressure", "register": 61, "words": 1, "datatype": "uint16", "typecast": "float", "multiplier": 0.1, "unit": "psi"},
+    "oil_pressure": {"description": "Oil pressure", "register": 61, "words": 1, "datatype": "uint16", "typecast": "float", "multiplier": 0.1, "unit": "psi"}
   }
 }

--- a/src/node_mgmt/node.py
+++ b/src/node_mgmt/node.py
@@ -106,6 +106,8 @@ class Node(object):
         # Load drivers from files, and also add any from the config
         self.drivers = self.__get_drivers()
         self.update_drv_from_config()
+        # Updates data endpoints if present in the remote config
+        self.update_endpoints_from_config()
 
     @property
     def node_id(self) -> str:
@@ -316,3 +318,13 @@ class Node(object):
                 self.drivers.update(self.config['drivers'])
             except AttributeError:
                 self.drivers = self.config['drivers']
+
+    def update_endpoints_from_config(self) -> None:
+        """
+        Check whether there are custom endpoints in the config definition, and if so update the data_endpoints
+        """
+        if 'data_endpoints' in self.config:
+            try:
+                self.data_endpoints = self.config['data_endpoints']
+            except Exception:
+                logger.exception('Exception raised while updating data-endpoints from config')


### PR DESCRIPTION
Hey @svet-b 

I added the method to check dynamically for endpoints in the config. 
I envisioned the new `data_endpoints` part in the config as a list of dicts: 

```
 "data_endpoints": [
    {
      "name": "mqtt",
      "type": "mqtt",
      "config": {
        "cert": "ca.crt",
        "host": "mqtt.ammp.io",
        "port": 8883
      }
    },
    {
      "name": "mqtt-stage",
      "type": "mqtt",
      "config": {
        "cert": "ca-stage.crt",
        "host": "mqtt.stage.ammp.io",
        "port": 8883
      }
    }
  ],
```

I tested it locally and it works well -- restart of the `ammp-edge` process is needed, but I think is fine for now

Also, while testing I came across a minimal malformation on the Cummins driver.

