### PR TITLE
AMMP-1788 Include speedwire meters to the env_scan service

### DIFF
--- a/src/node_mgmt/env_scan.py
+++ b/src/node_mgmt/env_scan.py
@@ -363,10 +363,6 @@ class EnvScanner(object):
         self.serial_env = SerialEnv(default_serial_dev=serial_dev)
         self.speedwire_env = SpeedWireReader()
 
-    def speedwire_scan(self):
-        serial_numbers = self.speedwire_env.scan_serials()
-        return serial_numbers
-
     def do_scan(self):
         network_hosts = self.net_env.network_scan()
         try:
@@ -374,7 +370,7 @@ class EnvScanner(object):
         except Exception:
             logger.exception("Exception while running ModbusTCP scan")
         serial_devices = self.serial_env.serial_scan()
-        speedwire_serials = self.speedwire_scan()
+        speedwire_serials = self.speedwire_env.scan_serials()
 
         scan_result = {
             'time':
@@ -385,10 +381,8 @@ class EnvScanner(object):
                 'netmask': self.net_env.default_netmask_bits,
                 'hosts': network_hosts
             }],
-            'serial_scan':
-            serial_devices,
-            'speedwire_serials':
-            speedwire_serials
+            'serial_scan': serial_devices,
+            'speedwire_serials': speedwire_serials
         }
 
         return scan_result

--- a/src/node_mgmt/env_scan.py
+++ b/src/node_mgmt/env_scan.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from kvstore import KVStore
 from reader.modbusrtu_reader import Reader as ModbusRTUReader
 from reader.modbustcp_reader import Reader as ModbusTCPReader
+from reader.sma_speedwire_reader import Reader as SpeedWireReader
 from processor import process_reading
 
 logger = logging.getLogger(__name__)
@@ -360,6 +361,11 @@ class EnvScanner(object):
 
         self.net_env = NetworkEnv(default_ifname=ifname)
         self.serial_env = SerialEnv(default_serial_dev=serial_dev)
+        self.speedwire_env = SpeedWireReader()
+
+    def speedwire_scan(self):
+        serial_numbers = self.speedwire_env.scan_serials()
+        return serial_numbers
 
     def do_scan(self):
         network_hosts = self.net_env.network_scan()
@@ -368,6 +374,7 @@ class EnvScanner(object):
         except Exception:
             logger.exception("Exception while running ModbusTCP scan")
         serial_devices = self.serial_env.serial_scan()
+        speedwire_serials = self.speedwire_scan()
 
         scan_result = {
             'time':
@@ -379,7 +386,9 @@ class EnvScanner(object):
                 'hosts': network_hosts
             }],
             'serial_scan':
-            serial_devices
+            serial_devices,
+            'speedwire_serials':
+            speedwire_serials
         }
 
         return scan_result

--- a/src/reader/sma_speedwire_reader.py
+++ b/src/reader/sma_speedwire_reader.py
@@ -15,7 +15,7 @@ MAX_RESPONSES = 5
 class Reader(object):
     def __init__(
         self,
-        serial: int,
+        serial: int = None,
         group: str = MULTICAST_GROUP,
         port: int = MULTICAST_PORT,
         recv_buffer_size: int = DEFAULT_RECV_BUFFER_SIZE,
@@ -84,6 +84,17 @@ class Reader(object):
                     break
 
         return self.__get_value(self._stored_values, obis_channel, obis_type)
+
+    def scan_serials(self) -> list:
+        serials = []
+        for _ in range(self._max_responses):
+            datagram = self.__get_datagram()
+            if datagram is None:
+                break
+            serial_number, _ = parse_datagram(datagram)
+            if serial_number not in serials:
+                serials.append(serial_number)
+        return serials
 
     @staticmethod
     def __get_value(values: dict, obis_channel: int, obis_type: int) -> bytes:


### PR DESCRIPTION
Hi @svet-b pls see the initial changes of this PR. 

I basically followed[ your ideas](https://ammpio.atlassian.net/browse/AMMP-1788?atlOrigin=eyJpIjoiYWM0MmU2NTZkODI1NDNjMTgzMTgzYzdmZGRhMWExOGYiLCJwIjoiaiJ9). 

New: 

- method to read the speedwire serial numbers
- import it to the `env_scan` process

For the env_scan I thought of making a new section -- **speedwire_serials**, instead of joining it with the Serial readings or the Network readings. 