### PR TITLE
AMMP-1919 Tesla Site Controller Driver

### DIFF
--- a/drivers/tesla_site_controller.json
+++ b/drivers/tesla_site_controller.json
@@ -72,7 +72,7 @@
       "register": 310,
       "unit": "Hz",
       "words": 1,
-      "multiplier": 0.01,
+      "multiplier": 0.001,
       "datatype":"uint16",
       "description": "AC frequency"
     },
@@ -131,7 +131,7 @@
       "register": 410,
       "unit": "Hz",
       "words": 1,
-      "multiplier": 0.01,
+      "multiplier": 0.001,
       "datatype":"uint16",
       "description": "AC frequency"
     },
@@ -190,7 +190,7 @@
       "register": 510,
       "unit": "Hz",
       "words": 1,
-      "multiplier": 0.01,
+      "multiplier": 0.001,
       "datatype":"uint16",
       "description": "AC frequency"
     },

--- a/drivers/tesla_site_controller.json
+++ b/drivers/tesla_site_controller.json
@@ -3,6 +3,34 @@
     "fncode": 3
   },
   "fields": {
+    "status_batt_E_full": {
+      "register": 205,
+      "unit": "Wh",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Available full charge energy at nominal temperature"
+    },
+    "status_batt_E_remaining": {
+      "register": 207,
+      "unit": "Wh",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Energy remaining at nominal temp (25°C)"
+    },
+    "status_batt_P_max_charge": {
+      "register": 211,
+      "unit": "W",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Maximum charge power"
+    },
+    "status_batt_P_max_discharge": {
+      "register": 213,
+      "unit": "W",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Maximum discharge power"
+    },
     "batt_P_total": {
       "register": 300,
       "unit": "W",
@@ -53,14 +81,132 @@
       "unit": "Wh",
       "words": 4,
       "datatype":"uint64",
-      "description": "AC frequency"
+      "description": "Real exported energy (accumulator)"
     },
     "batt_E_imported": {
       "register": 315,
       "unit": "Wh",
       "words": 4,
       "datatype":"uint64",
+      "description": "Real imported energy (accumulator)"
+    },
+    "grid_P_total": {
+      "register": 400,
+      "unit": "W",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Total 3 phase real power"
+    },
+    "grid_Q_total": {
+      "register": 402,
+      "unit": "VAr",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Total 3 phase reactive power"
+    },
+    "grid_S_total": {
+      "register": 404,
+      "unit": "VA",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Total 3 phase apparent power"
+    },
+    "grid_V": {
+      "register": 406,
+      "unit": "V",
+      "words": 2,
+      "multiplier": 0.1,
+      "datatype":"int32",
+      "description": "AC voltage"
+    },
+    "grid_I": {
+      "register": 408,
+      "unit": "A",
+      "words": 2,
+      "multiplier": 0.1,
+      "datatype":"int32",
+      "description": "AC current"
+    },
+    "grid_freq": {
+      "register": 410,
+      "unit": "Hz",
+      "words": 1,
+      "multiplier": 0.01,
+      "datatype":"uint16",
       "description": "AC frequency"
+    },
+    "grid_E_exported": {
+      "register": 411,
+      "unit": "Wh",
+      "words": 4,
+      "datatype":"uint64",
+      "description": "Real exported energy (accumulator)"
+    },
+    "grid_E_imported": {
+      "register": 415,
+      "unit": "Wh",
+      "words": 4,
+      "datatype":"uint64",
+      "description": "Real imported energy (accumulator)"
+    },
+    "load_P_total": {
+      "register": 500,
+      "unit": "W",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Power"
+    },
+    "load_Q_total": {
+      "register": 502,
+      "unit": "VAr",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Reactive power"
+    },
+    "load_S_total": {
+      "register": 504,
+      "unit": "VA",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Apparent power"
+    },
+    "load_V": {
+      "register": 506,
+      "unit": "V",
+      "words": 2,
+      "multiplier": 0.1,
+      "datatype":"int32",
+      "description": "AC voltage"
+    },
+    "load_I": {
+      "register": 508,
+      "unit": "A",
+      "words": 2,
+      "multiplier": 0.1,
+      "datatype":"int32",
+      "description": "AC current"
+    },
+    "load_freq": {
+      "register": 510,
+      "unit": "Hz",
+      "words": 1,
+      "multiplier": 0.01,
+      "datatype":"uint16",
+      "description": "AC frequency"
+    },
+    "load_E_exported": {
+      "register": 511,
+      "unit": "Wh",
+      "words": 4,
+      "datatype":"uint64",
+      "description": "Exported energy (accumulator)"
+    },
+    "load_E_imported": {
+      "register": 515,
+      "unit": "Wh",
+      "words": 4,
+      "datatype":"uint64",
+      "description": "Imported energy (accumulator)"
     },
     "pvinv_P_total": {
       "register": 600,
@@ -179,6 +325,34 @@
       "words": 4,
       "datatype":"uint64",
       "description": "Imported energy (accumulator)"
+    },
+    "alert_meter_comms": {
+      "register": 2500,
+      "unit": "",
+      "words": 1,
+      "datatype":"uint16",
+      "description": "Loss of meter communications"
+    },
+    "alert_batt_comms": {
+      "register": 2501,
+      "unit": "",
+      "words": 1,
+      "datatype":"uint16",
+      "description": "Fault or inverter block communication issue"
+    },
+    "alert_limits_reached": {
+      "register": 2502,
+      "unit": "",
+      "words": 1,
+      "datatype":"uint16",
+      "description": "Indication system limits have been reached"
+    },
+    "alert_command_timeout": {
+      "register": 2504,
+      "unit": "",
+      "words": 1,
+      "datatype":"uint16",
+      "description": "Direct command timeout"
     }
   }
 }

--- a/drivers/tesla_site_controller.json
+++ b/drivers/tesla_site_controller.json
@@ -120,6 +120,65 @@
       "words": 4,
       "datatype":"uint64",
       "description": "Imported energy (accumulator)"
+    },
+    "genset_P_total": {
+      "register": 900,
+      "unit": "W",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Power"
+    },
+    "genset_Q_total": {
+      "register": 902,
+      "unit": "VAr",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Reactive power"
+    },
+    "genset_S_total": {
+      "register": 904,
+      "unit": "VA",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Apparent Power"
+    },
+    "genset_V": {
+      "register": 906,
+      "unit": "V",
+      "words": 2,
+      "datatype":"int32",
+      "multiplier": 0.1,
+      "description": "AC voltage"
+    },
+    "genset_I": {
+      "register": 908,
+      "unit": "A",
+      "words": 2,
+      "datatype":"int32",
+      "multiplier": 0.1,
+      "description": "AC current"
+    },
+    "genset_freq": {
+      "register": 910,
+      "unit": "Hz",
+      "words": 1,
+      "datatype":"uint16",
+      "multiplier": 0.001,
+      "description": "AC frequency"
+    },
+    "genset_E_exported": {
+      "register": 911,
+      "unit": "Wh",
+      "words": 4,
+      "datatype":"uint64",
+      "description": "Exported energy (accumulator)"
+    },
+    "genset_E_imported": {
+      "register": 915,
+      "unit": "Wh",
+      "words": 4,
+      "datatype":"uint64",
+      "description": "Imported energy (accumulator)"
     }
   }
 }

--- a/drivers/tesla_site_controller.json
+++ b/drivers/tesla_site_controller.json
@@ -1,0 +1,125 @@
+{
+  "common": {
+    "fncode": 3
+  },
+  "fields": {
+    "batt_P_total": {
+      "register": 300,
+      "unit": "W",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Total 3 phase real power"
+    },
+    "batt_Q_total": {
+      "register": 302,
+      "unit": "VAr",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Total 3 phase reactive power"
+    },
+    "batt_S_total": {
+      "register": 304,
+      "unit": "VA",
+      "words": 2,
+      "datatype":"int32",
+      "description": "Total 3 phase apparent power"
+    },
+    "batt_V": {
+      "register": 306,
+      "unit": "V",
+      "words": 2,
+      "multiplier": 0.1,
+      "datatype":"int32",
+      "description": "3 phase average AC voltage"
+    },
+    "batt_I": {
+      "register": 308,
+      "unit": "A",
+      "words": 2,
+      "multiplier": 0.1,
+      "datatype":"int32",
+      "description": "3 phase total AC current"
+    },
+    "batt_freq": {
+      "register": 310,
+      "unit": "Hz",
+      "words": 1,
+      "multiplier": 0.01,
+      "datatype":"uint16",
+      "description": "AC frequency"
+    },
+    "batt_E_exported": {
+      "register": 311,
+      "unit": "Wh",
+      "words": 4,
+      "datatype":"uint64",
+      "description": "AC frequency"
+    },
+    "batt_E_imported": {
+      "register": 315,
+      "unit": "Wh",
+      "words": 4,
+      "datatype":"uint64",
+      "description": "AC frequency"
+    },
+    "pvinv_P_total": {
+      "register": 600,
+      "unit": "W",
+      "words": 2,
+      "datatype":"int32",
+      "description": "PV power"
+    },
+    "pvinv_Q_total": {
+      "register": 602,
+      "unit": "VAr",
+      "words": 2,
+      "datatype":"int32",
+      "description": "PV reactive power"
+    },
+    "pvinv_S_total": {
+      "register": 604,
+      "unit": "VA",
+      "words": 2,
+      "datatype":"int32",
+      "description": "PV apparent power"
+    },
+    "pvinv_V": {
+      "register": 606,
+      "unit": "V",
+      "words": 2,
+      "datatype":"int32",
+      "multiplier": 0.1,
+      "description": "PV AC voltage"
+    },
+    "pvinv_I": {
+      "register": 608,
+      "unit": "A",
+      "words": 2,
+      "datatype":"int32",
+      "multiplier": 0.1,
+      "description": "PV AC current"
+    },
+    "pvinv_freq": {
+      "register": 610,
+      "unit": "Hz",
+      "words": 1,
+      "datatype":"uint16",
+      "multiplier": 0.001,
+      "description": "PV AC frequency"
+    },
+    "pvinv_E_exported": {
+      "register": 611,
+      "unit": "Wh",
+      "words": 4,
+      "datatype":"uint64",
+      "description": "Exported energy (accumulator)"
+    },
+    "pvinv_E_imported": {
+      "register": 615,
+      "unit": "Wh",
+      "words": 4,
+      "datatype":"uint64",
+      "description": "Imported energy (accumulator)"
+    }
+  }
+}

--- a/drivers/tesla_site_controller.json
+++ b/drivers/tesla_site_controller.json
@@ -3,6 +3,12 @@
     "fncode": 3
   },
   "fields": {
+    "status_island": {
+      "register": 217,
+      "words": 1,
+      "datatype":"int16",
+      "description": "1 = Auto Active, 2 = Island Ready (standby state)"
+    },
     "status_batt_E_full": {
       "register": 205,
       "unit": "Wh",


### PR DESCRIPTION
Hi @svet-b this is the driver we have developed for Ofgen. At the moment is being tested at 2 sites already in `prod`

Important Note (probably better documented in Confluence):

- Tesla doesn't provide a SoC reading. Instead it provides the means to calculate it based on` batt_full` and `batt_remaining`. For now I have done the calculation using JSONata in the config of the logger. 