### PR TITLE
AMMP-2355: remove ammp-edge API from data-endpoints in remote.yaml

### DIFF
--- a/config/remote.yaml
+++ b/config/remote.yaml
@@ -2,12 +2,6 @@ api:
   host: edge.ammp.io
   apiver: v0
 data-endpoints:
-  - name: api
-    type: api
-    config:
-      host: edge.ammp.io
-      apiver: v0
-      timeout: 120
   - name: mqtt
     type: mqtt
     isdefault: true


### PR DESCRIPTION
Removing the ammp-edge API from the data-endpoints in the `remote.yaml` file.

From there on, I'll push the new snap and update the snap version of the dataloggers. I'll also correct the configs where the data-endpoints were overwritten.