### PR TITLE
AMMP-2410: add holykells (and secondary cummins and apm) in serial scan

### DIFF
--- a/src/node_mgmt/env_scan.py
+++ b/src/node_mgmt/env_scan.py
@@ -95,10 +95,42 @@ SERIAL_SCAN_SIGNATURES = [{
     'datatype': 'int16',
     'fncode': 4
 }, {
+    'name': 'APM303 genset controller',
+    'slave_id': 6,
+    'reading': 'oil pressure (bar)',
+    'register': 28,
+    'words': 1,
+    'datatype': 'int16',
+    'fncode': 4
+}, {
     'name': 'Cummins PS0600',
     'slave_id': 4,
     'reading': 'genset state',
     'register': 10,
+    'words': 1,
+    'datatype': 'uint16',
+    'fncode': 3
+}, {
+    'name': 'Cummins PS0600',
+    'slave_id': 3,
+    'reading': 'genset state',
+    'register': 10,
+    'words': 1,
+    'datatype': 'uint16',
+    'fncode': 3
+}, {
+    'name': 'Holykell HPT604',
+    'slave_id': 7,
+    'reading': 'fuel level (distance from sensor (mm))',
+    'register': 2,
+    'words': 1,
+    'datatype': 'uint16',
+    'fncode': 3
+}, {
+    'name': 'Holykell HPT604',
+    'slave_id': 8,
+    'reading': 'fuel level (distance from sensor (mm))',
+    'register': 2,
     'words': 1,
     'datatype': 'uint16',
     'fncode': 3


### PR DESCRIPTION
Adding the detection of holykells either on slave address 7 or 8 (in case of sites with two tanks and fuel sensors, which is happening with Daystar).

I also added the detection of secondary Cummins and APM gensets in the scan at the addresses where they are conventionally assigned (addresses 3 and 6 respectively).

So we end up with:

- 1: gamicos
- 2: IMT
- 3: Cummins
- 4: Cummins
- 5: APM
- 6: APM
- 7: Holykell
- 8: Holykell