### PR TITLE
AMMP-2469: add Carlo Gavazzi device in serial scan

### DIFF
--- a/src/node_mgmt/constants.py
+++ b/src/node_mgmt/constants.py
@@ -116,6 +116,14 @@ SERIAL_SCAN_SIGNATURES = [{
     'words': 1,
     'datatype': 'uint16',
     'fncode': 3
+}, {
+    'name': 'Carlo Gavazzi meter EM24',
+    'slave_id': 9,
+    'reading': 'Frequency (Hz*10)',
+    'register': 55,
+    'words': 1,
+    'datatype': 'int16',
+    'fncode': 3
 }]
 
 DEFAULT_SERIAL_BAUD_RATE = 9600


### PR DESCRIPTION
Hey Svet, here is the small change for the detection of the Carlo Gavazzi in the serial scan.