### PR TITLE
AMMP-2622: add **kwargs to initialisation of SNMP Reader

### DIFF
--- a/src/reader/snmp_reader.py
+++ b/src/reader/snmp_reader.py
@@ -5,7 +5,7 @@ from easysnmp import Session
 import builtins
 
 class Reader(object):
-    def __init__(self, host, port=161, community='public', version=2, timeout=60):
+    def __init__(self, host, port=161, community='public', version=2, timeout=60, **kwargs):
 
         self._host = host
         self._port = port


### PR DESCRIPTION
The `__init__()` from the Reader class of the `snmp_reader` does not have a `**kwargs` argument. It can be problematic if for example we enter the MAC address of the device we want to read, from which we get the host IP, but we still have the MAC as an argument, and since it is not an argument of the Reader initialisation, an error is thrown.

Note: for AKCP it isn’t a main roadblocker, because I can directly enter the host which is static. But it might be an issue for future integrations.