### PR TITLE
AMMP-2552: add akcp sensorprobe driver

### DIFF
--- a/drivers/akcp_sensorprobe.json
+++ b/drivers/akcp_sensorprobe.json
@@ -1,0 +1,5 @@
+{
+    "fields": {
+        "genset_fuel_volume": { "oid": ".1.3.6.1.4.1.3854.3.5.26.1.4.0.0.0.0.0", "description": "Fuel volume", "unit": "L", "datatype": "int32", "typecast": "int"}
+    }
+}


### PR DESCRIPTION
added driver for AKCP equipment. I called the driver `akcp_sensorprobe` because ultimately we might be able to read other AKCP sensors beyond the pressure sensor via their sensorProbe device.