### PR TITLE
consolidate readings in default provisioned config

### DIFF
--- a/drivers/sys_generic.json
+++ b/drivers/sys_generic.json
@@ -7,6 +7,7 @@
   "fields": {
     "disk_usage": {"method": "disk_usage", "args": {"path": "/"}, "keypath": [3], "unit": "%", "description": "Disk usage"},
     "cpu_load": {"module": "os", "method": "getloadavg", "keypath": [0], "description": "CPU load"},
+    "cpu_temp": {"method": "sensors_temperatures", "keypath": ["cpu_thermal", 0, 1], "unit": "C", "description": "CPU temperature"},
     "memory_usage": {"method": "virtual_memory", "keypath": [2], "unit": "%", "description": "Memory usage"},
     "boot_time": {"method": "boot_time", "keypath": [], "unit": "epoch", "description": "Boot time"}
   }

--- a/provisioning/config.json
+++ b/provisioning/config.json
@@ -8,20 +8,13 @@
       "enabled": true,
       "vendor_id": "strato-1",
       "reading_type": "sys"
-    },
-    "logger_strato": {
-      "name": "Logger (StratoPi extension)",
-      "driver": "sys_rpi3",
-      "enabled": true,
-      "vendor_id": "strato-1",
-      "reading_type": "sys"
     }
   },
   "readings": {
     "comms_lggr_boot_time": {"device": "logger", "var": "boot_time"},
     "comms_lggr_cpu_load": {"device": "logger", "var": "cpu_load"},
-    "comms_lggr_cpu_temp": {"device": "logger_strato", "var": "cpu_temp"},
-    "comms_lggr_disk_usage": {"device": "logger_strato", "var": "disk_usage"},
+    "comms_lggr_cpu_temp": {"device": "logger", "var": "cpu_temp"},
+    "comms_lggr_disk_usage": {"device": "logger", "var": "disk_usage"},
     "comms_lggr_mem_usage": {"device": "logger", "var": "memory_usage"}
   },
   "timestamp": "2022-08-15T13:03:17Z",

--- a/tests/config/provisioning/config.json
+++ b/tests/config/provisioning/config.json
@@ -8,19 +8,12 @@
       "enabled": true,
       "vendor_id": "strato-1",
       "reading_type": "sys"
-    },
-    "logger_strato": {
-      "name": "Logger (StratoPi extension)",
-      "driver": "sys_rpi3",
-      "enabled": true,
-      "vendor_id": "strato-1",
-      "reading_type": "sys"
     }
   },
   "readings": {
     "comms_lggr_boot_time": {"device": "logger", "var": "boot_time"},
     "comms_lggr_cpu_load": {"device": "logger", "var": "cpu_load"},
-    "comms_lggr_disk_usage": {"device": "logger_strato", "var": "disk_usage"},
+    "comms_lggr_disk_usage": {"device": "logger", "var": "disk_usage"},
     "comms_lggr_mem_usage": {"device": "logger", "var": "memory_usage"}
   },
   "timestamp": "2022-08-15T13:03:17Z",


### PR DESCRIPTION
There's no great reason to have two separate devices for the logger, so makes sense to consolidate into a single datalogger device