### PR TITLE
AMMP-3102: wait for reliable time source

### DIFF
--- a/rust/src/command/mod.rs
+++ b/rust/src/command/mod.rs
@@ -3,9 +3,11 @@ mod kvs;
 mod mqtt_pub;
 mod mqtt_sub;
 mod sma_hycon_csv;
+mod wait_for_time_source;
 
 pub use init::init;
 pub use kvs::{kvs_get, kvs_set};
 pub use mqtt_pub::mqtt_pub_meta;
 pub use mqtt_sub::mqtt_sub_cfg_cmd;
 pub use sma_hycon_csv::read_sma_hycon_csv;
+pub use wait_for_time_source::wait_for_time_source;

--- a/rust/src/command/wait_for_time_source.rs
+++ b/rust/src/command/wait_for_time_source.rs
@@ -1,0 +1,131 @@
+use std::{fmt::Display, io, process::Command, thread, time};
+
+use anyhow::anyhow;
+
+use crate::{helpers, interfaces::mqtt};
+
+const TIMEDATECTL_CMD: &str = "/usr/bin/timedatectl";
+const TIMEDATECTL_SUBCMD: &str = "show";
+
+fn into_permanent_err<E: Display>(err: E) -> backoff::Error<String> {
+    backoff::Error::Permanent(err.to_string())
+}
+
+pub fn wait_for_time_source() -> anyhow::Result<()> {
+    let check_time_sync = || {
+        let timedatectl_output = run_timedatectl_show().map_err(into_permanent_err)?;
+
+        let (rtc_time_0, ntp_sync) = rtc_time_and_ntp_status(&timedatectl_output);
+
+        if ntp_sync {
+            log::info!("NTP synchronized");
+            return Ok(());
+        }
+
+        thread::sleep(time::Duration::from_secs(2));
+        let timedatectl_output = run_timedatectl_show().map_err(into_permanent_err)?;
+        let (rtc_time_1, _) = rtc_time_and_ntp_status(&timedatectl_output);
+
+        if rtc_time_1 != rtc_time_0 {
+            log::info!("RTC appears functional");
+            Ok(())
+        } else {
+            let err_msg = format!(
+                "no time source available; 'timedatectl show' output: {:?}",
+                timedatectl_output
+            );
+            mqtt::publish_log_msg(&err_msg).ok();
+            Err(backoff::Error::transient(err_msg))
+        }
+    };
+
+    match helpers::backoff_retry(check_time_sync, None) {
+        Ok(_) => Ok(()),
+        Err(backoff::Error::Permanent(e)) => Err(anyhow!("unable to check time sources: {}", e)),
+        // In principle transient errors would be retried infinitely, so this should never happen, but needs to be handled...
+        Err(backoff::Error::Transient {
+            err: e,
+            retry_after: _,
+        }) => Err(anyhow!(
+            "transient error while checking time sources: {}",
+            e
+        )),
+    }
+}
+
+fn run_timedatectl_show() -> Result<String, io::Error> {
+    let output = Command::new(TIMEDATECTL_CMD)
+        .arg(TIMEDATECTL_SUBCMD)
+        .output()?;
+
+    if !output.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("timedatectl returned exit code {:?}", output.status.code()),
+        ));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn rtc_time_and_ntp_status(timedatectl_output: &str) -> (Option<String>, bool) {
+    let rtc_time = timedatectl_output
+        .lines()
+        .find(|line| line.starts_with("RTCTimeUSec="))
+        .and_then(|line| line.split_once('='))
+        .map(|(_, value)| value.to_string());
+
+    let ntp_sync = timedatectl_output.contains("NTPSynchronized=yes");
+
+    (rtc_time, ntp_sync)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const TIMEDATECTL_NTP_RTC: &str = r#"
+Timezone=Etc/UTC
+LocalRTC=no
+CanNTP=yes
+NTP=yes
+NTPSynchronized=yes
+TimeUSec=Thu 2023-04-13 21:03:24 UTC
+RTCTimeUSec=Thu 2023-04-13 21:03:24 UTC
+"#;
+
+    const TIMEDATECTL_NO_NTP_RTC_0: &str = r#"
+Timezone=Etc/UTC
+LocalRTC=no
+CanNTP=yes
+NTP=yes
+NTPSynchronized=no
+TimeUSec=Thu 2023-04-13 21:03:24 UTC
+RTCTimeUSec=Thu 2023-04-13 21:03:24 UTC
+"#;
+
+    const TIMEDATECTL_NO_NTP_RTC_1: &str = r#"
+Timezone=Etc/UTC
+LocalRTC=no
+CanNTP=yes
+NTP=yes
+NTPSynchronized=no
+TimeUSec=Thu 2023-04-13 21:03:25 UTC
+RTCTimeUSec=Thu 2023-04-13 21:03:25 UTC
+"#;
+
+    #[test]
+    fn test_parse_timedatectl_output() {
+        let (rtc_time, ntp_sync) = rtc_time_and_ntp_status(TIMEDATECTL_NTP_RTC);
+        println!("rtc_time: {:?}", rtc_time);
+        assert!(!rtc_time.unwrap().is_empty());
+        assert!(ntp_sync);
+
+        let (rtc_time_0, ntp_sync) = rtc_time_and_ntp_status(TIMEDATECTL_NO_NTP_RTC_0);
+        assert!(!ntp_sync);
+
+        let (rtc_time_1, ntp_sync) = rtc_time_and_ntp_status(TIMEDATECTL_NO_NTP_RTC_1);
+        assert!(rtc_time_0 != rtc_time_1);
+        assert!(!ntp_sync);
+    }
+}

--- a/rust/src/constants/topics.rs
+++ b/rust/src/constants/topics.rs
@@ -9,3 +9,5 @@ pub const META_BOOT_TIME: &str = "u/meta/boot_time";
 pub const META_START_TIME: &str = "u/meta/start_time";
 pub const META_SNAP_REV: &str = "u/meta/snap_rev";
 pub const META_SSH_FINGERPRINT: &str = "u/meta/ssh_fingerprint";
+
+pub const LOG_MSG: &str = "u/log/msg";

--- a/rust/src/interfaces/mqtt.rs
+++ b/rust/src/interfaces/mqtt.rs
@@ -7,6 +7,7 @@ use once_cell::sync::Lazy;
 use rumqttc::{Client, Connection, Event, MqttOptions, Packet, QoS};
 use thiserror::Error;
 
+use crate::constants::topics;
 use crate::constants::{defaults, envvars};
 use crate::helpers;
 
@@ -111,6 +112,17 @@ pub fn publish_msgs(
     }
     client.disconnect()?;
     Ok(())
+}
+
+pub fn publish_log_msg(log_msg: &str) -> Result<(), MqttError> {
+    publish_msgs(
+        &[MqttMessage {
+            topic: topics::LOG_MSG.into(),
+            payload: log_msg.into(),
+        }],
+        "local-pub-log-msg".into(),
+        false,
+    )
 }
 
 pub fn sub_topics(

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -15,6 +15,7 @@ const CMD_KVS_SET: &str = "kvs-set";
 const CMD_MQTT_PUB_META: &str = "mqtt-pub-meta";
 const CMD_MQTT_SUB_CFG_CMD: &str = "mqtt-sub-cfg-cmd";
 const CMD_READ_SMA_HYCON_CSV: &str = "read-sma-hycon-csv";
+const CMD_WAIT_FOR_TIME_SOURCE: &str = "wait-for-time-source";
 
 fn main() -> Result<()> {
     load_dotenv();
@@ -36,8 +37,12 @@ fn main() -> Result<()> {
         Some(CMD_MQTT_PUB_META) => command::mqtt_pub_meta(),
         Some(CMD_MQTT_SUB_CFG_CMD) => command::mqtt_sub_cfg_cmd(),
         Some(CMD_READ_SMA_HYCON_CSV) => command::read_sma_hycon_csv(),
+        Some(CMD_WAIT_FOR_TIME_SOURCE) => command::wait_for_time_source(),
         _ => Err(anyhow!(
-            "Subcommand must be one of '{CMD_INIT}', '{CMD_KVS_GET}', '{CMD_KVS_SET}', '{CMD_MQTT_PUB_META}', '{CMD_MQTT_SUB_CFG_CMD}', '{CMD_READ_SMA_HYCON_CSV}'"
+            r#"
+            Subcommand must be one of '{CMD_INIT}', '{CMD_KVS_GET}', '{CMD_KVS_SET}', '{CMD_MQTT_PUB_META}', '{CMD_MQTT_SUB_CFG_CMD}',
+            '{CMD_WAIT_FOR_TIME_SOURCE}', '{CMD_READ_SMA_HYCON_CSV}'
+            "#
         )),
     }
 }

--- a/rust/src/readers/sma_hycon_csv/mod.rs
+++ b/rust/src/readers/sma_hycon_csv/mod.rs
@@ -67,8 +67,12 @@ fn read_csv_from_device(device: &Device) -> Result<Vec<Record>, SmaHyconCsvError
 
 fn select_devices_to_read(config: &Config) -> Vec<Device> {
     config
-        .devices.iter()
-        .map(|(k, d)| Device { key: k.into(), ..d.clone()})
+        .devices
+        .iter()
+        .map(|(k, d)| Device {
+            key: k.into(),
+            ..d.clone()
+        })
         .filter(|d| d.reading_type == ReadingType::SmaHyconCsv && d.enabled)
         .collect()
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,7 +28,7 @@ apps:
     daemon: oneshot
     plugs: [network]
   ae-wait-for-time-source:
-    command: bin/ae ae-wait-for-time-source
+    command: bin/ae wait-for-time-source
     daemon: oneshot
   mosquitto:
     command: bin/mosquitto_svc.sh

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,6 +27,9 @@ apps:
     command: bin/ae init
     daemon: oneshot
     plugs: [network]
+  ae-wait-for-time-source:
+    command: bin/ae ae-wait-for-time-source
+    daemon: oneshot
   mosquitto:
     command: bin/mosquitto_svc.sh
     daemon: simple
@@ -54,7 +57,7 @@ apps:
     daemon: simple
     restart-condition: always
     restart-delay: 2s
-    after: [ae-init, mosquitto]
+    after: [ae-init, ae-wait-for-time-source, mosquitto]
     plugs:
       - network
       - network-bind
@@ -99,8 +102,9 @@ apps:
   read-sma-hycon-csv:
     command: bin/ae read-sma-hycon-csv
     daemon: oneshot
-    plugs: [network]
     timer: 03:00
+    after: [ae-init, ae-wait-for-time-source, mosquitto]
+    plugs: [network]
 
 parts:
   ammp-edge:


### PR DESCRIPTION
Adds a service `ae-wait-for-time-source` which will keep running until it's able to establish that a reliable time source is available - either NTP sync, or a well-functioning RTC. The main `ammp-edge` service will wait for it to complete before starting.