### PR TITLE
tweaks to HyCon CSV reading

### DIFF
--- a/rust/src/helpers/backoff_retry.rs
+++ b/rust/src/helpers/backoff_retry.rs
@@ -11,8 +11,10 @@ where
     F: FnMut() -> Result<T, backoff::Error<E>>,
     E: Display,
 {
+    let fn_name = std::any::type_name::<F>();
+
     let notify = |err, dur: Duration| {
-        log::error!("Temporary error after {:.1}s: {}", dur.as_secs_f32(), err);
+        log::error!("when running '{}' temporary error after {:.1}s: {}", fn_name, dur.as_secs_f32(), err);
     };
 
     // Set to retry forever, rather than give up after 15 minutes.

--- a/rust/src/readers/sma_hycon_csv/mod.rs
+++ b/rust/src/readers/sma_hycon_csv/mod.rs
@@ -51,7 +51,7 @@ fn read_device(device: &Device, readings: &mut Vec<DeviceReading>) -> Result<(),
 
     match records {
         Ok(records) => {
-            log::trace!("Readings: {:#?}", &records);
+            log::trace!("readings: {:?}", &records);
             records.into_iter().for_each(|r| {
                 readings.push(DeviceReading {
                     device: device.clone(),
@@ -60,7 +60,7 @@ fn read_device(device: &Device, readings: &mut Vec<DeviceReading>) -> Result<(),
             });
         }
         Err(e) => {
-            log::error!("Error reading CSV from device {:?}: {:#?}", device, e);
+            log::error!("error reading CSV from device {:?}: {}", device, e);
         }
     }
     Ok(())

--- a/rust/src/readers/sma_hycon_csv/mod.rs
+++ b/rust/src/readers/sma_hycon_csv/mod.rs
@@ -75,18 +75,11 @@ fn read_csv_from_device(device: &Device) -> Result<Vec<Record>, SmaHyconCsvError
     };
 
     let timezone = timezone::get_timezone(device)?;
-    let clock_offset = timezone::get_clock_offset(device).unwrap_or_else(|err| {
-        log::warn!(
-            "Error '{}' while getting clock offset for device {:?}; assuming zero offset",
-            err,
-            device
-        );
-        chrono::Duration::zero()
-    });
+    let clock_offset = timezone::try_get_clock_offset(device);
     log::info!(
-        "HyCon timezone: {:?}; clock offset: {:?}",
+        "HyCon timezone: {}; clock offset: {}s",
         timezone,
-        clock_offset
+        clock_offset.num_seconds()
     );
     let records = parse::parse_csv(csv_file, &driver::SMA_HYCON_CSV, timezone, clock_offset)?;
     Ok(records)

--- a/rust/src/readers/sma_hycon_csv/timezone.rs
+++ b/rust/src/readers/sma_hycon_csv/timezone.rs
@@ -1,9 +1,15 @@
+use std::time::Duration as StdDuration;
+
 use chrono::Duration;
 use chrono_tz::Tz;
 
-use crate::{interfaces::ntp, node_mgmt::config::Device};
+use crate::helpers::backoff_retry;
+use crate::interfaces::ntp;
+use crate::node_mgmt::config::Device;
 
 use super::{download::get_base_url, SmaHyconCsvError};
+
+const NTP_RETRY_TIMEOUT: Option<StdDuration> = Some(StdDuration::from_secs(15));
 
 pub fn get_timezone(device: &Device) -> Result<chrono_tz::Tz, SmaHyconCsvError> {
     device
@@ -25,4 +31,19 @@ pub fn get_clock_offset(device: &Device) -> Result<Duration, SmaHyconCsvError> {
         .ok_or(SmaHyconCsvError::Address("missing hostname".into()))?
         .to_string();
     Ok(ntp::query_offset_wrt_systime(&hostname, None)?)
+}
+
+pub fn try_get_clock_offset(device: &Device) -> Duration {
+    backoff_retry(
+        || get_clock_offset(device).map_err(backoff::Error::transient),
+        NTP_RETRY_TIMEOUT,
+    )
+    .unwrap_or_else(|err| {
+        log::warn!(
+            "error '{}'\nwhile getting NTP clock offset for device {:?}\nassuming zero offset",
+            err,
+            device
+        );
+        Duration::zero()
+    })
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -102,7 +102,7 @@ apps:
   read-sma-hycon-csv:
     command: bin/ae read-sma-hycon-csv
     daemon: oneshot
-    timer: 03:00
+    timer: 02:00~02:30
     after: [ae-init, ae-wait-for-time-source, mosquitto]
     plugs: [network]
 


### PR DESCRIPTION
- "fuzzy" timing between 2-2:30am (rather than all units running simultaneously at 3am)
- retry reading on failure, for up to 30 minutes
- retry timestamp over NTP for up to 15 seconds
- improved log messages